### PR TITLE
Fix GCC 14 compatibility issues

### DIFF
--- a/lib/gtk-v4l-device.c
+++ b/lib/gtk-v4l-device.c
@@ -401,5 +401,5 @@ void gtk_v4l_device_update_controls (Gtkv4lDevice *self)
 
 gboolean gtk_v4l_device_supports_ctrl_events (Gtkv4lDevice *self)
 {
-  return self->priv->channel;
+  return self->priv->channel != NULL;
 }

--- a/src/gtk-v4l.c
+++ b/src/gtk-v4l.c
@@ -68,7 +68,7 @@ v4l2_combo_add_device(Gtkv4lDeviceList *devlist,
   gint active;
   GtkComboBox *combo = GTK_COMBO_BOX(user_data);
 
-  gtk_combo_box_text_insert_text (combo, idx, device->card);
+  gtk_combo_box_text_insert_text (GTK_COMBO_BOX_TEXT (combo), idx, device->card);
   active = gtk_combo_box_get_active (combo);
   if (active == -1)
   {
@@ -88,7 +88,7 @@ v4l2_combo_remove_device(Gtkv4lDeviceList *devlist,
   /* If this removes the current device
      v4l2_combo_change_device_cb() will get called and that will
      handle selecting a new device. */
-  gtk_combo_box_text_remove (combo, idx);
+  gtk_combo_box_text_remove (GTK_COMBO_BOX_TEXT (combo), idx);
   if ((gtk_tree_model_iter_n_children( gtk_combo_box_get_model (combo),NULL)) == 0)
     gtk_widget_set_sensitive (default_button, FALSE);
 }


### PR DESCRIPTION
Prevent build failures with GCC 14 and current Clang due to C type errors that were previously flagged as warnings only.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
